### PR TITLE
fix(jq): update organization and executable names for 1.7 release

### DIFF
--- a/lua/mason-registry/jq/init.lua
+++ b/lua/mason-registry/jq/init.lua
@@ -9,7 +9,7 @@ local coalesce, when = _.coalesce, _.when
 return Pkg.new {
     name = "jq",
     desc = [[Command-line JSON processor]],
-    homepage = "https://github.com/stedolan/jq",
+    homepage = "https://github.com/jqlang/jq",
     languages = { Pkg.Lang.JSON },
     categories = { Pkg.Cat.Formatter },
     ---@async
@@ -17,14 +17,16 @@ return Pkg.new {
     install = function(ctx)
         github
             .download_release_file({
-                repo = "stedolan/jq",
+                repo = "jqlang/jq",
                 out_file = platform.is.win and "jq.exe" or "jq",
                 asset_file = coalesce(
-                    when(platform.is.mac, "jq-osx-amd64"),
-                    when(platform.is.linux_x86, "jq-linux32"),
-                    when(platform.is.linux_x64, "jq-linux64"),
-                    when(platform.is.win_x86, "jq-win32.exe"),
-                    when(platform.is.win_x64, "jq-win64.exe")
+                    when(platform.is.mac_x64, "jq-macos-amd64"),
+                    when(platform.is.mac_arm64, "jq-macos-arm64"),
+                    when(platform.is.linux_x86, "jq-linux-i386"),
+                    when(platform.is.linux_x64, "jq-linux-amd64"),
+                    when(platform.is.linux_arm64, "jq-linux-arm64"),
+                    when(platform.is.win_x86, "jq-windows-i386.exe"),
+                    when(platform.is.win_x64, "jq-windows-amd64.exe")
                 ),
             })
             .with_receipt()


### PR DESCRIPTION
[jq 1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7) has been released in the new organization jqlang. 
jq maintainers changed the executable names to support various CPU architectures.
This PR fixes the executable name for the new release.
They temporarily added the executable with old names to fix for the latest URLs (https://github.com/jqlang/jq/issues/2877).
But they might not retain the executable with the old names.